### PR TITLE
feat: add user specific config

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -26,22 +26,31 @@ func init() {
 	var err error
 
 	firstRun := true
-	if helpers.FileExists(config.DATABASE_FILE) {
+	if helpers.FileExists(config.Config.DatabasePath) {
 		firstRun = false
 	} else {
 		log.Debug("Database not found, creating it")
-		err = helpers.CreateFile(config.DATABASE_FILE)
+		err = helpers.CreateFile(config.Config.DatabasePath)
 		if err != nil {
-			log.Error("Could not create database (path: %s), error: %+v", config.DATABASE_FILE, err)
+			log.Error("Could not create database (path: %s), error: %+v", config.Config.DatabasePath, err)
+		}
+
+		// remove "last_migration" if exists, else the new database is empty
+		lastMigration := helpers.JoinPath(config.USER_DIR, "last_migration")
+		if helpers.FileExists(lastMigration) {
+			err = helpers.RemoveFile(lastMigration)
+			if err != nil {
+				log.Error("Could not remove last_migration: %s, error: %+v", lastMigration, err)
+			}
 		}
 	}
 
-	db, err = sql.Open("sqlite3", config.DATABASE_FILE)
+	db, err = sql.Open("sqlite3", config.Config.DatabasePath)
 	if err != nil {
-		fmt.Printf("Could not open database: %s\n", config.DATABASE_FILE)
+		fmt.Printf("Could not open database: %s\n", config.Config.DatabasePath)
 		os.Exit(1)
 	}
-	log.Debug("Successfully connected to db: %s", config.DATABASE_FILE)
+	log.Debug("Successfully connected to db: %s", config.Config.DatabasePath)
 
 	if firstRun {
 		err := runMigrations(config.MIGRATIONS_DIR, config.USER_DIR)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,10 +1,17 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/mikeunge/Tasker/pkg/helpers"
 )
+
+type IConfig struct {
+	DatabasePath string `json:"database_path"`
+	LogPath      string `json:"log_path"`
+}
 
 const (
 	APP_NAME        = "Tasker"
@@ -16,13 +23,20 @@ const (
 
 // This are dev variables - they get modified in the init() function
 var (
-	APP_ENV        = os.Getenv("APP_ENV")
-	PWD, _         = os.Getwd()
-	USER_DIR       = helpers.ExpandPath("~/.tasker")
-	DATABASE_FILE  = USER_DIR + "/database.sqlite"
-	LOG_FILE       = USER_DIR + "/tasker.log"
-	MIGRATIONS_DIR = PWD + "/migrations"
+	APP_ENV         = os.Getenv("APP_ENV")
+	PWD, _          = os.Getwd()
+	USER_CONFIG_DIR = helpers.ExpandPath("~/.config/tasker")
+	USER_CONFIG     = USER_CONFIG_DIR + "/config.json"
+	USER_DIR        = helpers.ExpandPath("~/.tasker")
+	database_path   = USER_DIR + "/database.sqlite"
+	log_path        = USER_DIR + "/tasker.log"
+	MIGRATIONS_DIR  = PWD + "/migrations"
 )
+
+var Config = IConfig{
+	DatabasePath: database_path,
+	LogPath:      log_path,
+}
 
 func init() {
 	if helpers.GetStringLength(PWD) <= 0 {
@@ -33,4 +47,30 @@ func init() {
 	if APP_ENV != "developer" {
 		MIGRATIONS_DIR = APP_DIR + "/migrations"
 	}
+
+	// user specific config
+	if !helpers.PathExists(USER_CONFIG_DIR) {
+		err := helpers.CreateDirectory(USER_CONFIG_DIR)
+		if err != nil {
+			return
+		}
+
+		// try to create the config file with some default data
+		data, _ := json.MarshalIndent(Config, "", " ")
+		err = helpers.WriteFile(USER_CONFIG, string(data[:]))
+		if err != nil {
+			fmt.Printf("Could not create %s\nError: %+v\n", USER_CONFIG, err)
+		}
+	} else {
+		data, err := helpers.ReadFileBytes(USER_CONFIG)
+		if err != nil {
+			return
+		}
+
+		err = json.Unmarshal(data, &Config)
+		if err != nil {
+			fmt.Printf("Could not parse config, please make sure the config is valid json.\nError: %+v\n", err)
+		}
+	}
+
 }

--- a/pkg/helpers/file_helpers.go
+++ b/pkg/helpers/file_helpers.go
@@ -108,3 +108,16 @@ func GetFilesInDir(path string) ([]string, error) {
 
 	return files, nil
 }
+
+/**
+ * RemoveFile(string) error
+ *
+ * Remove a file, returns error on fail.
+ */
+func RemoveFile(path string) error {
+	err := os.Remove(path)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -28,7 +28,7 @@ func SetLogLevel(level string) {
 
 func WriteLogToFile(writeToFile bool) {
 	if writeToFile && helpers.PathExists(config.USER_DIR) {
-		file, err := os.OpenFile(config.LOG_FILE, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		file, err := os.OpenFile(config.Config.LogPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
 			panic(fmt.Sprintf("error opening file: %v", err))
 		}


### PR DESCRIPTION
Add user specific config.
Added IConfig - where the user can change the 1) LogPath and 2) the DatabasePath.

The database path can be used for a shared task system (_not tested tho_), but in theory the database can be accessed from more than 1 person via a network drive. IDK how this behaves, how the database handle locking and all that but might be interesting to test.